### PR TITLE
feat: first implementations of the `crypto` and `currency` palettes

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -9,32 +9,47 @@ version: 2
 
 before:
   hooks:
-    - go mod tidy
+  - go mod tidy
 
 builds:
-  - env:
-      - CGO_ENABLED=0
-    goos:
-      - linux
-      - windows
-      - darwin
-    ldflags:
-      - -s -w -X github.com/lentidas/hledger-price-tracker/cmd.version={{.Version}} -X github.com/lentidas/hledger-price-tracker/cmd.commit={{.Commit}} -X github.com/lentidas/hledger-price-tracker/cmd.date={{.Date}}
+- env:
+  - CGO_ENABLED=0
+  goos:
+  - linux
+  - windows
+  - darwin
+  ldflags:
+  - -s -w -X github.com/lentidas/hledger-price-tracker/cmd.version={{.Version}} -X github.com/lentidas/hledger-price-tracker/cmd.commit={{.Commit}} -X github.com/lentidas/hledger-price-tracker/cmd.date={{.Date}}
 
 archives:
-  - formats: [tar.gz]
-    # This name template makes the OS and Arch compatible with the results of `uname`.
-    name_template: >-
-      {{ .ProjectName }}_
-      {{- title .Os }}_
-      {{- if eq .Arch "amd64" }}x86_64
-      {{- else if eq .Arch "386" }}i386
-      {{- else }}{{ .Arch }}{{ end }}
-      {{- if .Arm }}v{{ .Arm }}{{ end }}
-    # Use zip for Windows archives.
-    format_overrides:
-      - goos: windows
-        formats: [zip]
+- formats: [tar.gz]
+  # This name template makes the OS and Arch compatible with the results of `uname`.
+  name_template: >-
+    {{ .ProjectName }}_
+    {{- title .Os }}_
+    {{- if eq .Arch "amd64" }}x86_64
+    {{- else if eq .Arch "386" }}i386
+    {{- else }}{{ .Arch }}{{ end }}
+    {{- if .Arm }}v{{ .Arm }}{{ end }}
+  # Use zip for Windows archives.
+  format_overrides:
+  - goos: windows
+    formats: [zip]
 
 changelog:
   disable: true
+
+brews:
+- name: hledger-price-tracker
+
+  homepage: https://github.com/lentidas/hledger-price-tracker
+  description: A CLI tool to get market prices for commodities.
+  license: GPL-3.0-or-later
+
+  commit_author:
+    name: repository-bot[bot]
+    email: 191768328+repository-bot[bot]@users.noreply.github.com
+
+  repository:
+    owner: lentidas
+    name: homebrew-tap

--- a/README.md
+++ b/README.md
@@ -170,7 +170,9 @@ This command allows you to get the price of a stock symbol, either daily, weekly
 The following example shows the price of IBM stock in the weekly interval for the entirety of the available data.
 
 ```shell
-$ hledger-price-tracker stock price IBM --api-key demo
+hledger-price-tracker stock price IBM --api-key demo
+```
+```
 P 1999-11-12 "IBM" 95.87 NIL
 P 1999-11-19 "IBM" 103.94 NIL
 P 1999-11-26 "IBM" 105.00 NIL

--- a/cmd/crypto/crypto.go
+++ b/cmd/crypto/crypto.go
@@ -1,0 +1,47 @@
+/*
+ * hledger-price-tracker - a CLI tool to get market prices for commodities
+ * Copyright (C) 2024 Gonçalo Carvalheiro Heleno
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package crypto
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// PaletteCmd represents the currency command palette.
+var PaletteCmd = &cobra.Command{
+	Use:     "crypto",
+	GroupID: "palette",
+	Short:   "Palette command that groups all subcommands related to cryptocurrencies",
+	Long: `
+hledger-price-tracker
+
+Palette command that groups all subcommands related to cryptocurrencies and
+their exchange rates.`,
+
+	Run: func(cmd *cobra.Command, args []string) {
+		// Print the help message for this command palette.
+		err := cmd.Help()
+		if err != nil {
+			os.Exit(1)
+		}
+	},
+}
+
+func init() {}

--- a/cmd/crypto/list.go
+++ b/cmd/crypto/list.go
@@ -1,0 +1,55 @@
+/*
+ * hledger-price-tracker - a CLI tool to get market prices for commodities
+ * Copyright (C) 2024 Gonçalo Carvalheiro Heleno
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package crypto
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/lentidas/hledger-price-tracker/internal/crypto/list"
+	"github.com/lentidas/hledger-price-tracker/internal/flags"
+)
+
+// Define the output flag and set it to the default value.
+var formatList = flags.OutputFormatTable
+
+// listCmd represents the list command.
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all available digital currencies",
+	Long: `
+hledger-price-tracker
+
+Command to list all available physical currencies.`,
+
+	Run: func(cmd *cobra.Command, args []string) {
+		output, err := list.Execute(formatList)
+		cobra.CheckErr(err)
+		fmt.Print(output)
+	},
+}
+
+func init() {
+	// Add this subcommand to the `currency` command palette.
+	PaletteCmd.AddCommand(listCmd)
+
+	// Add flags to the `list` subcommand.
+	listCmd.Flags().VarP(&formatList, "format", "f", "format of the output (possible values are \"csv\" and \"table\")")
+}

--- a/cmd/currency/currency.go
+++ b/cmd/currency/currency.go
@@ -19,7 +19,6 @@
 package currency
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -31,12 +30,12 @@ var PaletteCmd = &cobra.Command{
 	GroupID: "palette",
 	Short:   "Palette command that groups all subcommands related to currencies",
 	Long: `
-TODO`, // TODO
+hledger-price-tracker
+
+Palette command that groups all subcommands related to currencies and
+their exchange rates.`,
 
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("currency called") // TODO Remove these debug lines
-		fmt.Println()
-
 		// Print the help message for this command palette.
 		err := cmd.Help()
 		if err != nil {
@@ -45,14 +44,4 @@ TODO`, // TODO
 	},
 }
 
-func init() {
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// PaletteCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// PaletteCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
-}
+func init() {}

--- a/cmd/currency/list.go
+++ b/cmd/currency/list.go
@@ -1,0 +1,55 @@
+/*
+ * hledger-price-tracker - a CLI tool to get market prices for commodities
+ * Copyright (C) 2024 Gonçalo Carvalheiro Heleno
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package currency
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/lentidas/hledger-price-tracker/internal/currency/list"
+	"github.com/lentidas/hledger-price-tracker/internal/flags"
+)
+
+// Define the output flag and set it to the default value.
+var formatList = flags.OutputFormatTable
+
+// listCmd represents the list command.
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all available physical currencies",
+	Long: `
+hledger-price-tracker
+
+Command to list all available physical currencies.`,
+
+	Run: func(cmd *cobra.Command, args []string) {
+		output, err := list.Execute(formatList)
+		cobra.CheckErr(err)
+		fmt.Print(output)
+	},
+}
+
+func init() {
+	// Add this subcommand to the `currency` command palette.
+	PaletteCmd.AddCommand(listCmd)
+
+	// Add flags to the `list` subcommand.
+	listCmd.Flags().VarP(&formatList, "format", "f", "format of the output (possible values are \"csv\" and \"table\")")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -27,6 +27,7 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
+	"github.com/lentidas/hledger-price-tracker/cmd/crypto"
 	"github.com/lentidas/hledger-price-tracker/cmd/currency"
 	"github.com/lentidas/hledger-price-tracker/cmd/stock"
 	"github.com/lentidas/hledger-price-tracker/internal"
@@ -75,6 +76,7 @@ func init() {
 	// Add all subcommand palettes to the root command.
 	rootCmd.AddCommand(stock.PaletteCmd)
 	rootCmd.AddCommand(currency.PaletteCmd)
+	rootCmd.AddCommand(crypto.PaletteCmd)
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/stock/stock.go
+++ b/cmd/stock/stock.go
@@ -19,7 +19,6 @@
 package stock
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -31,12 +30,11 @@ var PaletteCmd = &cobra.Command{
 	GroupID: "palette",
 	Short:   "Palette command that groups all subcommands related to stocks",
 	Long: `
-TODO`, // TODO
+hledger-price-tracker
+
+Palette command that groups all subcommands related to stocks.`,
 
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("stock called") // TODO Remove these debug lines
-		fmt.Println()
-
 		// Print the help message for this command palette.
 		err := cmd.Help()
 		if err != nil {

--- a/internal/crypto/list/list.go
+++ b/internal/crypto/list/list.go
@@ -1,0 +1,95 @@
+/*
+ * hledger-price-tracker - a CLI tool to get market prices for commodities
+ * Copyright (C) 2024 Gonçalo Carvalheiro Heleno
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package list
+
+import (
+	"bytes"
+	"encoding/csv"
+	"errors"
+	"fmt"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+
+	"github.com/lentidas/hledger-price-tracker/internal"
+	"github.com/lentidas/hledger-price-tracker/internal/flags"
+)
+
+const url = "https://www.alphavantage.co/digital_currency_list/"
+
+type Crypto struct {
+	Code string
+	Name string
+}
+
+type Cryptos []Crypto
+
+func (obj *Cryptos) GenerateOutput(body []byte, format flags.OutputFormat) (string, error) {
+	switch format {
+	case flags.OutputFormatHledger, flags.OutputFormatJSON, flags.OutputFormatTableLong:
+		errorMessage := fmt.Sprintf("[(*Cryptos).GenerateOutput] %s output format not supported", format)
+		return "", errors.New(errorMessage)
+	case flags.OutputFormatCSV:
+		return string(body), nil
+	case flags.OutputFormatTable:
+		// Read CSV data.
+		csvReader := csv.NewReader(bytes.NewReader(body))
+		data, err := csvReader.ReadAll()
+		if err != nil {
+			return "", fmt.Errorf("[(*Cryptos).GenerateOutput] failure to read CSV data: %w", err)
+		}
+
+		// Parse CSV data into a slice of Crypto objects.
+		for i, line := range data {
+			if i > 0 { // Skip the header line.
+				var currency Crypto
+				for j, field := range line {
+					switch j {
+					case 0:
+						currency.Code = field
+					case 1:
+						currency.Name = field
+					}
+				}
+				*obj = append(*obj, currency)
+			}
+		}
+
+		// Create a table and send it to the output.
+		t := table.NewWriter()
+		t.SetStyle(table.StyleLight)
+		t.AppendHeader(table.Row{"Code", "Currency Name"})
+		for _, currency := range *obj {
+			t.AppendRow(table.Row{currency.Code, currency.Name})
+		}
+		return t.Render() + "\n", nil
+	default:
+		return "", errors.New("[(*Cryptos).GenerateOutput] invalid output format")
+	}
+}
+
+func Execute(format flags.OutputFormat) (string, error) {
+	body, err := internal.HTTPRequest(url)
+	if err != nil {
+		return "", err
+	}
+
+	response := Cryptos{}
+
+	return response.GenerateOutput(body, format)
+}

--- a/internal/currency/list/list.go
+++ b/internal/currency/list/list.go
@@ -1,0 +1,95 @@
+/*
+ * hledger-price-tracker - a CLI tool to get market prices for commodities
+ * Copyright (C) 2024 Gonçalo Carvalheiro Heleno
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package list
+
+import (
+	"bytes"
+	"encoding/csv"
+	"errors"
+	"fmt"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+
+	"github.com/lentidas/hledger-price-tracker/internal"
+	"github.com/lentidas/hledger-price-tracker/internal/flags"
+)
+
+const url = "https://www.alphavantage.co/physical_currency_list/"
+
+type Currency struct {
+	Code string
+	Name string
+}
+
+type Currencies []Currency
+
+func (obj *Currencies) GenerateOutput(body []byte, format flags.OutputFormat) (string, error) {
+	switch format {
+	case flags.OutputFormatHledger, flags.OutputFormatJSON, flags.OutputFormatTableLong:
+		errorMessage := fmt.Sprintf("[(*Currencies).GenerateOutput] %s output format not supported", format)
+		return "", errors.New(errorMessage)
+	case flags.OutputFormatCSV:
+		return string(body), nil
+	case flags.OutputFormatTable:
+		// Read CSV data.
+		csvReader := csv.NewReader(bytes.NewReader(body))
+		data, err := csvReader.ReadAll()
+		if err != nil {
+			return "", fmt.Errorf("[(*Currencies).GenerateOutput] failure to read CSV data: %w", err)
+		}
+
+		// Parse CSV data into a slice of Currency objects.
+		for i, line := range data {
+			if i > 0 { // Skip the header line.
+				var currency Currency
+				for j, field := range line {
+					switch j {
+					case 0:
+						currency.Code = field
+					case 1:
+						currency.Name = field
+					}
+				}
+				*obj = append(*obj, currency)
+			}
+		}
+
+		// Create a table and send it to the output.
+		t := table.NewWriter()
+		t.SetStyle(table.StyleLight)
+		t.AppendHeader(table.Row{"Code", "Currency Name"})
+		for _, currency := range *obj {
+			t.AppendRow(table.Row{currency.Code, currency.Name})
+		}
+		return t.Render() + "\n", nil
+	default:
+		return "", errors.New("[internal.search.generateSearchOutput] invalid output format")
+	}
+}
+
+func Execute(format flags.OutputFormat) (string, error) {
+	body, err := internal.HTTPRequest(url)
+	if err != nil {
+		return "", err
+	}
+
+	response := Currencies{}
+
+	return response.GenerateOutput(body, format)
+}

--- a/internal/stock/search/search.go
+++ b/internal/stock/search/search.go
@@ -128,7 +128,7 @@ func (obj *Search) TypeBody() error {
 func (obj *Search) GenerateOutput(body []byte, format flags.OutputFormat) (string, error) {
 	switch format {
 	case flags.OutputFormatHledger:
-		return "", errors.New("[internal.search.generateSearchOutput] hledger output format not supported")
+		return "", errors.New("[(*Search).GenerateOutput] hledger output format not supported")
 	case flags.OutputFormatJSON, flags.OutputFormatCSV:
 		return string(body), nil
 	case flags.OutputFormatTable, flags.OutputFormatTableLong:
@@ -190,7 +190,7 @@ func (obj *Search) GenerateOutput(body []byte, format flags.OutputFormat) (strin
 
 		return t.Render(), nil
 	default:
-		return "", errors.New("[internal.search.generateSearchOutput] invalid output format")
+		return "", errors.New("[(*Search).GenerateOutput] invalid output format")
 	}
 }
 
@@ -244,9 +244,13 @@ func GetCurrency(symbol string) (string, error) {
 		return "", fmt.Errorf("[stock.search.GetCurrency] error getting currency of symbol %s", symbol)
 	}
 
+	// If no results are found, return an error. An error is a correct in this case, because if the user uses a known
+	// stock symbol, the API should always return at least one result.
 	if len(response.BestMatches) < 1 {
 		return "", errors.New("[stock.search.GetCurrency] no results found")
 	}
+
+	// TODO Maybe consider also returning an error if the match score is not 100%.
 
 	return response.BestMatches[0].Currency, nil
 }


### PR DESCRIPTION
This PR adds the first implementations of the `crypto` and `currency` palettes.

Also, the GoRelease configuration now should create a Homebrew formula in my [personal tap](https://github.com/lentidas/homebrew-tap).