### PR TITLE
feat: implement physical currency historical exchange rates

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ The `hledger` format always uses the closing price of the day. The other formats
 The following example shows the exchange rates from EUR to USD stock in the weekly interval for the first months of 2025, specified using the `--begin` and `--end` flags.
 
 ```shell
-helder-price-tracker currency rate EUR USD --api-key demo --format table --begin 2025-01-01 --end 2025-03-31
+hledger-price-tracker currency rate EUR USD --api-key demo --format table --begin 2025-01-01 --end 2025-03-31
 ```
 ```
 ┌──────┬──────────┬─────────────────────┐

--- a/README.md
+++ b/README.md
@@ -19,8 +19,16 @@ CLI program to generate market price records for [hledger](https://hledger.org/)
 - [Table of Contents](#table-of-contents)
 - [Configuration](#configuration)
 - [Usage](#usage)
-  - [`stock search`](#stock-search)
-  - [`stock price`](#stock-price)
+  - [`currency`](#currency)
+    - [`currency list`](#currency-list)
+    - [`currency current`](#currency-current)
+    - [`currency rate`](#currency-rate)
+  - [`crypto`](#crypto)
+    - [`crypto list`](#crypto-list)
+    - [`crypto current`](#crypto-current)
+  - [`stock`](#stock)
+    - [`stock search`](#stock-search)
+    - [`stock price`](#stock-price)
 
 ## Configuration
 
@@ -46,7 +54,191 @@ default-currency: EUR
 
 ## Usage
 
-### `stock search`
+### `currency`
+
+#### `currency list`
+
+This command lists all the physical currencies available on the Alpha Vantage API. It was implemented to allow the user to check what is the 3-letter code for the currency they want to use, since this code is what the API expects.
+
+```shell
+hledger-price-tracker currency list
+```
+```
+┌──────┬─────────────────────────────────────┐
+│ CODE │ CURRENCY NAME                       │
+├──────┼─────────────────────────────────────┤
+│ AED  │ United Arab Emirates Dirham         │
+│ YER  │ Yemeni Rial                         │
+│ ...  │ ...                                 │
+│ ZMW  │ Zambian Kwacha                      │
+│ ZWL  │ Zimbabwean Dollar                   │
+└──────┴─────────────────────────────────────┘
+```
+
+> [!NOTE]
+> Actually, this command does not talk to the API directly, it simply parses [this CSV file](https://www.alphavantage.co/physical_currency_list/) from Alpha Vantage's documentation.
+
+> [!TIP]
+> You can use the `--format` or `-f` flag to get the same CSV output. *Other formats are not available.*
+
+#### `currency current`
+
+This command is used to get the current exchange rate between two currencies.
+
+It expects at least one argument, which is the currency for which you want to get the price to.
+
+The second argument is the currency you want to convert to. It defaults to `EUR` or the currency given to the `--currency` flag (the flag is always overridden by the second argument).
+
+> [!NOTE]
+> The commands `currency current` and `crypto current` are interchangeable, as there is a single API endpoint for getting the current exchange rate between two currencies, either physical or digital ones.
+
+```shell
+hledger-price-tracker currency current USD JPY --api-key demo
+```
+```
+P 2025-04-05 "USD" 146.94 "JPY"
+```
+
+You can specify a different output format using the `--format` or `-f` flag. The available formats are `hledger` (default), `table`, `table-long` (table with more information), and `json`.
+The `json` output is nothing more than the raw body of the response from the Alpha Vantage API.
+
+```shell
+hledger-price-tracker currency current USD JPY --api-key demo --format table
+```
+```
+┌─────┬─────────┬─────────────────────┐
+│ USD │     JPY │ LAST REFRESHED      │
+├─────┼─────────┼─────────────────────┤
+│ 1   │ 146.935 │ 2025-04-05 18:50:34 │
+└─────┴─────────┴─────────────────────┘
+```
+
+#### `currency rate`
+
+This command gets the historical exchange rates between two physical currencies, either daily, weekly, or monthly. The default interval is weekly and the default output is given in hledger syntax.
+
+The following command gets the weekly exchange rates from EUR to USD.
+
+```shell
+hledger-price-tracker currency rate EUR USD --api-key demo
+```
+```
+P 2015-04-12 "EUR" 1.06 "USD"
+P 2015-04-19 "EUR" 1.08 "USD"
+P 2015-04-26 "EUR" 1.09 "USD"
+
+...
+
+P 2025-03-16 "EUR" 1.09 "USD"
+P 2025-03-23 "EUR" 1.08 "USD"
+P 2025-03-30 "EUR" 1.08 "USD"
+P 2025-04-04 "EUR" 1.10 "USD"
+```
+
+There is also the `--format` or `-f` flag to specify a different output format. The available formats are `hledger` (default), `table`, `table-long`, `json`, and `csv`.
+
+The `hledger` format always uses the closing price of the day. The other formats show more information.
+
+The following example shows the exchange rates from EUR to USD stock in the weekly interval for the first months of 2025, specified using the `--begin` and `--end` flags.
+
+```shell
+helder-price-tracker currency rate EUR USD --api-key demo --format table --begin 2025-01-01 --end 2025-03-31
+```
+```
+┌──────┬──────────┬─────────────────────┐
+│ FROM │ CURRENCY │ LAST REFRESHED      │
+├──────┼──────────┼─────────────────────┤
+│ EUR  │ USD      │ 2025-04-04 21:25:00 │
+└──────┴──────────┴─────────────────────┘
+┌────────────┬──────┬──────┬──────┬───────┐
+│ DATE       │ OPEN │ HIGH │ LOW  │ CLOSE │
+├────────────┼──────┼──────┼──────┼───────┤
+│ 2025-01-05 │ 1.04 │ 1.04 │ 1.02 │ 1.03  │
+│ 2025-01-12 │ 1.04 │ 1.04 │ 1.02 │ 1.02  │
+│ 2025-01-19 │ 1.03 │ 1.04 │ 1.02 │ 1.03  │
+│ 2025-01-26 │ 1.04 │ 1.05 │ 1.03 │ 1.05  │
+│ 2025-02-02 │ 1.04 │ 1.05 │ 1.02 │ 1.02  │
+│ 2025-02-09 │ 1.03 │ 1.04 │ 1.03 │ 1.03  │
+│ 2025-02-16 │ 1.03 │ 1.05 │ 1.03 │ 1.05  │
+│ 2025-02-23 │ 1.05 │ 1.05 │ 1.04 │ 1.05  │
+│ 2025-03-02 │ 1.05 │ 1.05 │ 1.04 │ 1.04  │
+│ 2025-03-09 │ 1.05 │ 1.09 │ 1.05 │ 1.09  │
+│ 2025-03-16 │ 1.08 │ 1.09 │ 1.08 │ 1.09  │
+│ 2025-03-23 │ 1.09 │ 1.10 │ 1.08 │ 1.08  │
+│ 2025-03-30 │ 1.08 │ 1.08 │ 1.07 │ 1.08  │
+└────────────┴──────┴──────┴──────┴───────┘
+```
+
+### `crypto`
+
+#### `crypto list`
+
+This command lists all the digital currencies available on the Alpha Vantage API. It was implemented as a way to check what is the 3-letter code for the currency the user wants to use, since this code is what the API expects.
+
+```shell
+hledger-price-tracker crypto list
+```
+```
+┌───────────┬──────────────────────────────────┐
+│ CODE      │ CURRENCY NAME                    │
+├───────────┼──────────────────────────────────┤
+│ 1ST       │ FirstBlood                       │
+│ 2GIVE     │ GiveCoin                         │
+│ ...       │ ...                              │
+│ ZLA       │ Zilla                            │
+│ ZRX       │ 0x                               │
+└───────────┴──────────────────────────────────┘
+```
+
+> [!NOTE]
+> Actually, this command does not talk to the API directly, it simply parses [this CSV file](https://www.alphavantage.co/digital_currency_list/) from Alpha Vantage's documentation.
+
+> [!TIP]
+> You can use the `--format` or `-f` flag to get the same CSV output. *Other formats are not available.*
+
+#### `crypto current`
+
+This command is used to get the current exchange rate between the specified cryptocurrency and currency.
+
+It expects at least one argument, which is the cryptocurrency for which you want to get the price to.
+
+The second argument is the currency you want to convert to, for example, USD or EUR. It defaults to `EUR` or the currency given to the `--currency` flag (the flag is always overridden by the second argument).
+
+> [!NOTE]
+> The commands `crypto current` and `currency current` are interchangeable, as there is a single API endpoint for getting the current exchange rate between two currencies, either physical or digital ones.
+
+```shell
+hledger-price-tracker crypto current BTC --api-key demo
+```
+```
+P 2025-04-05 "BTC" 75670.94 "EUR"
+```
+
+You can specify a different output format using the `--format` or `-f` flag. The available formats are `hledger` (default), `table`, `table-long` (table with more information), and `json`.
+The `json` output is nothing more than the raw body of the response from the Alpha Vantage API.
+
+```shell
+hledger-price-tracker crypto current BTC --api-key demo --format table
+```
+```
+┌─────┬──────────┬─────────────────────┐
+│ BTC │      EUR │ LAST REFRESHED      │
+├─────┼──────────┼─────────────────────┤
+│ 1   │ 75682.92 │ 2025-04-05 18:44:29 │
+└─────┴──────────┴─────────────────────┘
+```
+
+<!--
+
+#### `crypto rate`
+
+TODO
+
+-->
+
+### `stock`
+
+#### `stock search`
 
 This command allows you to search for a stock symbol with a given query. The query can be a part of the company name or the stock symbol itself.
 
@@ -163,7 +355,7 @@ BAAAAX,Building America Strategy Port CDA USD Ser 21/1Q MNT CASH,Mutual Fund,Uni
 BAAAFX,Building America Strgy Portf CDA USD Ser 2022/2Q MNT CASH,Mutual Fund,United States,09:30,16:00,UTC-04,USD,0.5000
 ```
 
-### `stock price`
+#### `stock price`
 
 This command allows you to get the price of a stock symbol, either daily, weekly, or monthly. The default interval is weekly and the default output is given in hledger syntax.
 
@@ -225,16 +417,16 @@ P 2025-03-12 "IBM" 249.63 NIL
 > Also note how the stock symbol is displayed between double quotes. This is to avoid any issues with the hledger syntax, because some stock symbols contain special characters or numbers (p.e. `IBMB34.SAO` for IBM traded in São Paulo's exchange).
 
 > [!IMPORTANT]
-> The `default-currency` option has no effect on the output of the `price` subcommand, because the currency is defined by the stock symbol itself. For example, `IBM` is traded in USD, and `IBM.FRK` is traded in EUR, despite being the same publicly-traded company.
+> The `--currency` flag has no effect on the output of the `stock price` subcommand, because the currency is defined by the stock symbol itself. For example, `IBM` is traded in USD, and `IBM.FRK` is traded in EUR, despite being the same publicly-traded company.
 
 There is also the `--format` or `-f` flag to specify a different output format. The available formats are `hledger` (default), `table`, `table-long`, `json`, and `csv`.
 
 The `hledger` format always uses the closing price of the stock. The other formats show more information.
 
-The following example shows the price of IBM stock in the weekly interval for the first quarter of 2025, specified using the `--begin` and `--end` flags.
+The following example shows the price of IBM stock in the weekly interval for the first months of 2025, specified using the `--begin` and `--end` flags.
 
 ```shell
-hledger-price-tracker stock price IBM -k demo --format table --begin 2025-01-01 --end 2025-03-21
+hledger-price-tracker stock price IBM --api-key demo --format table --begin 2025-01-01 --end 2025-03-21
 ```
 ```
 ┌────────┬──────────┬────────────────┬────────────┐
@@ -265,7 +457,7 @@ hledger-price-tracker stock price IBM -k demo --format table --begin 2025-01-01 
 Alpha Vantage also provides the option to get an adjusted closing price, along with the given dividends. You can use the `--adjusted` or `-a` flag to get this information.
 
 ```shell
-hledger-price-tracker stock price IBM -k demo --format table-long --begin 2024-01-01 --end 2024-12-31 --adjusted
+hledger-price-tracker stock price IBM --api-key demo --format table-long --begin 2024-01-01 --end 2024-12-31 --adjusted
 ```
 ```
 ┌────────┬──────────┬────────────────┬────────────┐

--- a/cmd/crypto/current.go
+++ b/cmd/crypto/current.go
@@ -65,6 +65,6 @@ func init() {
 	// Add this subcommand to the `currency` command palette.
 	PaletteCmd.AddCommand(currentCmd)
 
-	// Add flags to the `list` subcommand.
+	// Add flags to the `current` subcommand.
 	currentCmd.Flags().VarP(&formatCurrent, "format", "f", "format of the output (possible values are \"hledger\", \"json\", \"table\", \"table-long\")")
 }

--- a/cmd/currency/current.go
+++ b/cmd/currency/current.go
@@ -65,6 +65,6 @@ func init() {
 	// Add this subcommand to the `currency` command palette.
 	PaletteCmd.AddCommand(currentCmd)
 
-	// Add flags to the `list` subcommand.
+	// Add flags to the `current` subcommand.
 	currentCmd.Flags().VarP(&formatCurrent, "format", "f", "format of the output (possible values are \"hledger\", \"json\", \"table\", \"table-long\")")
 }

--- a/cmd/currency/rate.go
+++ b/cmd/currency/rate.go
@@ -1,0 +1,81 @@
+/*
+ * hledger-price-tracker - a CLI tool to get market prices for commodities
+ * Copyright (C) 2024 Gonçalo Carvalheiro Heleno
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package currency
+
+import (
+	"fmt"
+	"github.com/lentidas/hledger-price-tracker/internal"
+	"github.com/lentidas/hledger-price-tracker/internal/currency/rate"
+
+	"github.com/spf13/cobra"
+
+	"github.com/lentidas/hledger-price-tracker/internal/flags"
+)
+
+var formatRate = flags.OutputFormatHledger
+var interval = flags.IntervalWeekly
+var begin string
+var end string
+var full bool
+
+// rateCmd represents the rate command.
+var rateCmd = &cobra.Command{
+	Use:   "rate [flags] <from-currency> [<to-currency>]",
+	Short: "Get the historical exchange rate between two physical currencies",
+	Long: `
+hledger-price-tracker
+
+Command to get the exchange rates between two currencies 
+in a certain time period and interval.
+
+It returns the open, high, low, and close exchange rates for each each interval 
+in the time period defined.
+
+API documentation:
+- https://www.alphavantage.co/documentation/#fx-daily
+- https://www.alphavantage.co/documentation/#fx-weekly
+- https://www.alphavantage.co/documentation/#fx-monthly`,
+
+	// Require the user to provide at least one argument, which is the currency we want to convert from.
+	Args: cobra.MinimumNArgs(1),
+
+	Run: func(cmd *cobra.Command, args []string) {
+		var to string
+		if len(args) < 2 {
+			to = internal.DefaultCurrency
+		} else {
+			to = args[1]
+		}
+		output, err := rate.Execute(args[0], to, formatRate, interval, begin, end, full)
+		cobra.CheckErr(err)
+		fmt.Print(output)
+	},
+}
+
+func init() {
+	// Add this subcommand to the `currency` command palette.
+	PaletteCmd.AddCommand(rateCmd)
+
+	// Add flags to the `rate` subcommand.
+	rateCmd.Flags().VarP(&formatRate, "format", "f", "format of the output (possible values are \"hledger\", \"json\", \"csv\", \"table\", \"table-long\")")
+	rateCmd.Flags().VarP(&interval, "interval", "i", "interval between prices (possible values are \"daily\", \"weekly\", \"monthly\")")
+	rateCmd.Flags().StringVarP(&begin, "begin", "b", "", "beginning of the time period (format YYYY-MM-DD) (does not apply to  \"json\" or \"csv\" output formats)")
+	rateCmd.Flags().StringVarP(&end, "end", "e", "", "end of the time period (format YYYY-MM-DD) (does not apply to  \"json\" or \"csv\" output formats)")
+	rateCmd.Flags().BoolVar(&full, "full", false, "for daily intervals, return all the data, otherwise return only the last 100 data points (does nothing for weekly or monthly intervals)")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -61,10 +61,6 @@ func init() {
 	cobra.OnInitialize(initConfig)
 
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "path to config file (default is $HOME/.hledger-price-tracker.yaml)")
-
-	// TODO Validate the currency flag against a list of valid currencies accepted by the Alpha Vantage API
-	//  https://www.alphavantage.co/physical_currency_list/
-	//  https://www.alphavantage.co/digital_currency_list/
 	rootCmd.PersistentFlags().StringVarP(&internal.DefaultCurrency, "currency", "c", "EUR", "default destination currency for exchange rates")
 	rootCmd.PersistentFlags().StringVarP(&internal.ApiKey, "api-key", "k", "", "API key to access the Alpha Vantage API")
 	rootCmd.PersistentFlags().BoolVar(&internal.DebugMode, "debug", false, "enable debug mode (disables a few API requests and prints more information)")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -65,7 +65,7 @@ func init() {
 	// TODO Validate the currency flag against a list of valid currencies accepted by the Alpha Vantage API
 	//  https://www.alphavantage.co/physical_currency_list/
 	//  https://www.alphavantage.co/digital_currency_list/
-	rootCmd.PersistentFlags().StringVarP(&internal.DefaultCurrency, "currency", "c", "EUR", "default currency for exchange rates")
+	rootCmd.PersistentFlags().StringVarP(&internal.DefaultCurrency, "currency", "c", "EUR", "default destination currency for exchange rates")
 	rootCmd.PersistentFlags().StringVarP(&internal.ApiKey, "api-key", "k", "", "API key to access the Alpha Vantage API")
 	rootCmd.PersistentFlags().BoolVar(&internal.DebugMode, "debug", false, "enable debug mode (disables a few API requests and prints more information)")
 	rootCmd.PersistentFlags().MarkHidden("debug")

--- a/internal/crypto/list/list_test.go
+++ b/internal/crypto/list/list_test.go
@@ -1,0 +1,71 @@
+/*
+ * hledger-price-tracker - a CLI tool to get market prices for commodities
+ * Copyright (C) 2024 Gonçalo Carvalheiro Heleno
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package list
+
+import "testing"
+
+func TestListCryptoExists(t *testing.T) {
+	// Define a slice of cryptocurrencies to test.
+	cryptos := []string{"BTC", "ETH", "LTC", "XRP"}
+
+	for _, crypto := range cryptos {
+		t.Run("crypto exists "+crypto, func(t *testing.T) {
+			result, err := CryptoExists(crypto)
+			if err != nil {
+				t.Errorf("expected nil, got %v", err)
+			} else if !result {
+				t.Errorf("expected %s to exist, got false", crypto)
+			}
+		})
+	}
+
+	// Define a slice of currencies to test.
+	currencies := []string{"EUR", "CHF", "GBP", "USD"}
+
+	for _, currency := range currencies {
+		t.Run("crypto does not exist "+currency, func(t *testing.T) {
+			result, err := CryptoExists(currency)
+			if err != nil {
+				t.Errorf("expected nil, got %v", err)
+			} else if result {
+				t.Errorf("expected %s to not exist, got true", currency)
+			}
+		})
+	}
+
+	// Test for empty crypto.
+	t.Run("failure empty", func(t *testing.T) {
+		result, err := CryptoExists("")
+		if err != nil {
+			t.Errorf("expected nil, got %v", err)
+		} else if result {
+			t.Errorf("expected false, got true")
+		}
+	})
+
+	// Test for non-existent crypto.
+	t.Run("failure INVALID", func(t *testing.T) {
+		result, err := CryptoExists("INVALID")
+		if err != nil {
+			t.Errorf("expected nil, got %v", err)
+		} else if result {
+			t.Errorf("expected false, got true")
+		}
+	})
+}

--- a/internal/currency/current/current.go
+++ b/internal/currency/current/current.go
@@ -170,6 +170,7 @@ func (obj *Current) GenerateOutput(body []byte, format flags.OutputFormat) (stri
 	}
 }
 
+// buildURL creates the URL to make the HTTP request to the Alpha Vantage API.
 func buildURL(from string, to string) (string, error) {
 	if internal.ApiKey == "" {
 		return "", errors.New("[currency/crypto.current.buildURL] API key is required")

--- a/internal/currency/current/current.go
+++ b/internal/currency/current/current.go
@@ -131,39 +131,37 @@ func (obj *Current) GenerateOutput(body []byte, format flags.OutputFormat) (stri
 				obj.Typed.ToCurrencyCode)
 			return output, nil
 		} else {
-			tMetadata := table.NewWriter()
-			tMetadata.SetStyle(table.StyleLight)
-			tMetadata.AppendHeader(table.Row{"From", "To", "Last Refreshed"})
-			tMetadata.AppendRow(table.Row{
-				fmt.Sprintf("%s (%s)", obj.Typed.FromCurrencyName, obj.Typed.FromCurrencyCode),
-				fmt.Sprintf("%s (%s)", obj.Typed.ToCurrencyName, obj.Typed.ToCurrencyCode),
-				obj.Typed.LastRefreshed.Format("2006-01-02 15:04:05"),
-			})
-
-			tData := table.NewWriter()
-			tData.SetStyle(table.StyleLight)
+			t := table.NewWriter()
+			t.SetStyle(table.StyleLight)
 			if format == flags.OutputFormatTable {
-				tData.AppendHeader(table.Row{
+				t.AppendHeader(table.Row{
 					obj.Typed.FromCurrencyCode,
 					obj.Typed.ToCurrencyCode,
+					"Last Refreshed",
 				})
-				tData.AppendRow(table.Row{"1", obj.Typed.ExchangeRate})
+				t.AppendRow(table.Row{
+					"1",
+					obj.Typed.ExchangeRate,
+					obj.Typed.LastRefreshed.Format("2006-01-02 15:04:05"),
+				})
 			} else {
-				tData.AppendHeader(table.Row{
+				t.AppendHeader(table.Row{
 					obj.Typed.FromCurrencyCode,
 					obj.Typed.ToCurrencyCode,
 					"Bid Price",
 					"Ask Price",
+					"Last Refreshed",
 				})
-				tData.AppendRow(table.Row{
+				t.AppendRow(table.Row{
 					"1",
 					obj.Typed.ExchangeRate,
 					obj.Typed.BidPrice,
 					obj.Typed.AskPrice,
+					obj.Typed.LastRefreshed.Format("2006-01-02 15:04:05"),
 				})
 			}
 
-			return tMetadata.Render() + "\n" + tData.Render() + "\n", nil
+			return t.Render() + "\n", nil
 		}
 	default:
 		return "", errors.New("[(*Current).GenerateOutput] invalid output format")

--- a/internal/currency/current/current_test.go
+++ b/internal/currency/current/current_test.go
@@ -28,9 +28,17 @@ import (
 func TestCurrent(t *testing.T) {
 	internal.ApiKey = "demo"
 
-	// t.Run("success", func(t *testing.T) {
-	// 	// TODO Implement expected response.
-	// })
+	t.Run("success from USD to JPY", func(t *testing.T) {
+		if _, err := Execute("USD", "JPY", flags.OutputFormatHledger); err != nil {
+			t.Errorf("expected nil, got %v", err)
+		}
+	})
+
+	t.Run("success from BTC to EUR", func(t *testing.T) {
+		if _, err := Execute("BTC", "EUR", flags.OutputFormatHledger); err != nil {
+			t.Errorf("expected nil, got %v", err)
+		}
+	})
 
 	t.Run("no origin currency", func(t *testing.T) {
 		if _, err := Execute("", "JPY", flags.OutputFormatHledger); err == nil {

--- a/internal/currency/list/list_test.go
+++ b/internal/currency/list/list_test.go
@@ -1,0 +1,71 @@
+/*
+ * hledger-price-tracker - a CLI tool to get market prices for commodities
+ * Copyright (C) 2024 Gonçalo Carvalheiro Heleno
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package list
+
+import "testing"
+
+func TestListCurrencyExists(t *testing.T) {
+	// Define a slice of currencies to test.
+	currencies := []string{"EUR", "CHF", "GBP", "USD"}
+
+	for _, currency := range currencies {
+		t.Run("currency exists "+currency, func(t *testing.T) {
+			result, err := CurrencyExists(currency)
+			if err != nil {
+				t.Errorf("expected nil, got %v", err)
+			} else if !result {
+				t.Errorf("expected %s to exist, got false", currency)
+			}
+		})
+	}
+
+	// Define a slice of cryptocurrencies to test.
+	cryptos := []string{"BTC", "ETH", "LTC", "XRP"}
+
+	for _, crypto := range cryptos {
+		t.Run("crypto does not exist "+crypto, func(t *testing.T) {
+			result, err := CurrencyExists(crypto)
+			if err != nil {
+				t.Errorf("expected nil, got %v", err)
+			} else if result {
+				t.Errorf("expected %s to not exist, got true", crypto)
+			}
+		})
+	}
+
+	// Test for empty currency.
+	t.Run("failure empty", func(t *testing.T) {
+		result, err := CurrencyExists("")
+		if err != nil {
+			t.Errorf("expected nil, got %v", err)
+		} else if result {
+			t.Errorf("expected false, got true")
+		}
+	})
+
+	// Test for non-existent currency.
+	t.Run("failure INVALID", func(t *testing.T) {
+		result, err := CurrencyExists("INVALID")
+		if err != nil {
+			t.Errorf("expected nil, got %v", err)
+		} else if result {
+			t.Errorf("expected false, got true")
+		}
+	})
+}

--- a/internal/currency/rate/rate.go
+++ b/internal/currency/rate/rate.go
@@ -57,7 +57,7 @@ type TypedMetadata struct {
 }
 
 func (typed *TypedMetadata) TypeBody(raw RawMetadata) error {
-	lastRefreshed, err := time.Parse("2006-01-02 15:04:05", raw.LastRefreshed)
+	lastRefreshed, err := time.Parse("2006-01-02", raw.LastRefreshed)
 	if err != nil {
 		return fmt.Errorf("[currency.rate.(*TypedMetadata).TypeBody] error parsing last refreshed date: %w", err)
 	}

--- a/internal/currency/rate/rate.go
+++ b/internal/currency/rate/rate.go
@@ -147,7 +147,7 @@ func (typed *TypedPrices) TypeBody(raw RawPrices) error {
 
 func buildURL(from string, to string, format flags.OutputFormat, interval flags.Interval, full bool) (string, error) {
 	if internal.ApiKey == "" {
-		return "", errors.New("[price.buildURL] API key is required")
+		return "", errors.New("[currency.rate.buildURL] API key is required")
 	}
 
 	fromBoolCurrency, err := currencyList.CurrencyExists(from)
@@ -172,7 +172,7 @@ func buildURL(from string, to string, format flags.OutputFormat, interval flags.
 	case flags.OutputFormatHledger, flags.OutputFormatTable, flags.OutputFormatTableLong, flags.OutputFormatJSON, flags.OutputFormatCSV:
 		// Do nothing.
 	default:
-		return "", errors.New("[price.buildURL] invalid output format")
+		return "", errors.New("[currency.rate.buildURL] invalid output format")
 	}
 
 	url := strings.Builder{}

--- a/internal/currency/rate/rate.go
+++ b/internal/currency/rate/rate.go
@@ -1,0 +1,306 @@
+/*
+ * hledger-price-tracker - a CLI tool to get market prices for commodities
+ * Copyright (C) 2024 Gonçalo Carvalheiro Heleno
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package rate
+
+import (
+	"errors"
+	"fmt"
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/lentidas/hledger-price-tracker/internal"
+	currencyList "github.com/lentidas/hledger-price-tracker/internal/currency/list"
+	"github.com/lentidas/hledger-price-tracker/internal/flags"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// TODO Add documentation to each of the functions
+
+type Response interface {
+	TypeBody() error
+	GenerateOutput(body []byte, begin time.Time, end time.Time, format flags.OutputFormat) (string, error)
+}
+
+type RawMetadata struct {
+	Information   string `json:"1. Information"`
+	FromSymbol    string `json:"2. From Symbol"`
+	ToSymbol      string `json:"3. To Symbol"`
+	LastRefreshed string `json:"4. Last Refreshed"`
+	TimeZone      string `json:"5. Time Zone"`
+}
+
+type TypedMetadata struct {
+	Information   string
+	FromSymbol    string
+	ToSymbol      string
+	LastRefreshed time.Time
+	TimeZone      string
+}
+
+func (typed *TypedMetadata) TypeBody(raw RawMetadata) error {
+	lastRefreshed, err := time.Parse("2006-01-02 15:04:05", raw.LastRefreshed)
+	if err != nil {
+		return fmt.Errorf("[currency.rate.(*TypedMetadata).TypeBody] error parsing last refreshed date: %w", err)
+	}
+
+	typed.Information = raw.Information
+	typed.FromSymbol = raw.FromSymbol
+	typed.ToSymbol = raw.ToSymbol
+	typed.LastRefreshed = lastRefreshed
+	typed.TimeZone = raw.TimeZone
+
+	return nil
+}
+
+type RawMetadataDaily struct {
+	Information   string `json:"1. Information"`
+	FromSymbol    string `json:"2. From Symbol"`
+	ToSymbol      string `json:"3. To Symbol"`
+	OutputSize    string `json:"4. Output Size"`
+	LastRefreshed string `json:"5. Last Refreshed"`
+	TimeZone      string `json:"6. Time Zone"`
+}
+
+type TypedMetadataDaily struct {
+	Information   string
+	FromSymbol    string
+	ToSymbol      string
+	OutputSize    string
+	LastRefreshed time.Time
+	TimeZone      string
+}
+
+func (typed *TypedMetadataDaily) TypeBody(raw RawMetadataDaily) error {
+	lastRefreshed, err := time.Parse("2006-01-02", raw.LastRefreshed)
+	if err != nil {
+		return fmt.Errorf("[currency.rate.(*TypedMetadataDaily).TypeBody] error parsing last refreshed date: %w", err)
+	}
+
+	typed.Information = raw.Information
+	typed.FromSymbol = raw.FromSymbol
+	typed.ToSymbol = raw.ToSymbol
+	typed.OutputSize = raw.OutputSize
+	typed.LastRefreshed = lastRefreshed
+	typed.TimeZone = raw.TimeZone
+
+	return nil
+}
+
+type RawPrices struct {
+	Open  string `json:"1. open"`
+	High  string `json:"2. high"`
+	Low   string `json:"3. low"`
+	Close string `json:"4. close"`
+}
+
+type TypedPrices struct {
+	Open  float64
+	High  float64
+	Low   float64
+	Close float64
+}
+
+func (typed *TypedPrices) TypeBody(raw RawPrices) error {
+	openPrice, err := strconv.ParseFloat(raw.Open, 64)
+	if err != nil {
+		return fmt.Errorf("[currency.rate.(*TypedPrices).TypeBody] error parsing open price: %w", err)
+	}
+	highPrice, err := strconv.ParseFloat(raw.High, 64)
+	if err != nil {
+		return fmt.Errorf("[currency.rate.(*TypedPrices).TypeBody] error parsing high price: %w", err)
+	}
+	lowPrice, err := strconv.ParseFloat(raw.Low, 64)
+	if err != nil {
+		return fmt.Errorf("[currency.rate.(*TypedPrices).TypeBody] error parsing low price: %w", err)
+	}
+	closePrice, err := strconv.ParseFloat(raw.Close, 64)
+	if err != nil {
+		return fmt.Errorf("[currency.rate.(*TypedPrices).TypeBody] error parsing close price: %w", err)
+	}
+
+	typed.Open = openPrice
+	typed.High = highPrice
+	typed.Low = lowPrice
+	typed.Close = closePrice
+
+	return nil
+}
+
+func buildURL(from string, to string, format flags.OutputFormat, interval flags.Interval, full bool) (string, error) {
+	if internal.ApiKey == "" {
+		return "", errors.New("[price.buildURL] API key is required")
+	}
+
+	fromBoolCurrency, err := currencyList.CurrencyExists(from)
+	if err != nil {
+		return "", err
+	} else if !fromBoolCurrency {
+		return "", errors.New("[currency.rate.buildURL] from currency is not valid")
+	}
+
+	toBoolCurrency, err := currencyList.CurrencyExists(to)
+	if err != nil {
+		return "", err
+	} else if !toBoolCurrency {
+		return "", errors.New("[currency.rate.buildURL] to currency is not valid")
+	}
+
+	if from == to {
+		return "", errors.New("[currency.rate.buildURL] from and to currencies must be different")
+	}
+
+	switch format {
+	case flags.OutputFormatHledger, flags.OutputFormatTable, flags.OutputFormatTableLong, flags.OutputFormatJSON, flags.OutputFormatCSV:
+		// Do nothing.
+	default:
+		return "", errors.New("[price.buildURL] invalid output format")
+	}
+
+	url := strings.Builder{}
+	url.WriteString(internal.ApiBaseUrl)
+	url.WriteString("function=")
+
+	switch interval {
+	case flags.IntervalDaily:
+		url.WriteString(apiFunctionCurrencyRateDaily)
+	case flags.IntervalWeekly:
+		url.WriteString(apiFunctionCurrencyRateWeekly)
+	case flags.IntervalMonthly:
+		url.WriteString(apiFunctionCurrencyRateMonthly)
+	default:
+		return "", errors.New("[currency.rate.buildURL] invalid interval for adjusted prices")
+	}
+
+	url.WriteString("&from_symbol=")
+	url.WriteString(from)
+	url.WriteString("&to_symbol=")
+	url.WriteString(to)
+
+	// Print entire time series if daily, because user can then limit the interval with `begin` and `end`.
+	if interval == flags.IntervalDaily && full {
+		url.WriteString("&outputsize=full")
+	}
+	url.WriteString("&apikey=")
+	url.WriteString(internal.ApiKey)
+
+	if format == flags.OutputFormatCSV {
+		url.WriteString("&datatype=csv")
+	}
+
+	return url.String(), nil
+}
+
+// createResponseObject creates a Response object with the proper struct that will be used to parse
+// the JSON body, depending on the interval.
+func createResponseObject(interval flags.Interval) (Response, error) {
+	var obj Response
+
+	switch interval {
+	case flags.IntervalDaily:
+		obj = &Daily{}
+	case flags.IntervalWeekly:
+		obj = &Weekly{}
+	case flags.IntervalMonthly:
+		obj = &Monthly{}
+	default:
+		return obj, errors.New("[currency.rate.createResponseObject] invalid interval")
+	}
+
+	return obj, nil
+}
+
+// getDates returns the dates in the time series that are within the specified interval.
+func getDates(timeSeries map[time.Time]TypedPrices, begin time.Time, end time.Time) []time.Time {
+	var dates []time.Time
+	for date := range timeSeries {
+		if !(date.Before(begin) || date.After(end)) {
+			dates = append(dates, date)
+		}
+	}
+
+	// TODO Implement sorting in chronologically AND reverse-chronologically order.
+	sort.Slice(dates, func(i, j int) bool {
+		return dates[i].Before(dates[j])
+	})
+
+	return dates
+}
+
+// generateOutputHledger generates the output in hledger format for non-adjusted prices.
+func generateOutputHledger(timeSeries map[time.Time]TypedPrices, dates []time.Time, from string, to string) string {
+	out := strings.Builder{}
+	for _, date := range dates {
+		out.WriteString(fmt.Sprintf("P %s \"%s\" %.2f \"%s\"\n",
+			date.Format("2006-01-02"),
+			from,
+			timeSeries[date].Close,
+			to))
+	}
+	return out.String()
+}
+
+func generateMetadataTable(from string, to string, lastRefreshed time.Time) string {
+	t := table.NewWriter()
+	t.SetStyle(table.StyleLight)
+	t.AppendHeader(table.Row{"From", "Currency", "Last Refreshed"})
+	t.AppendRow(table.Row{from, to, lastRefreshed.Format("2006-01-02 15:04:05")})
+	return t.Render() + "\n"
+}
+
+func generateTimeSeriesTable(timeSeries map[time.Time]TypedPrices, dates []time.Time) string {
+	t := table.NewWriter()
+	t.SetStyle(table.StyleLight)
+	t.AppendHeader(table.Row{"Date", "Open", "High", "Low", "Close"})
+	for _, date := range dates {
+		prices := timeSeries[date]
+		t.AppendRow([]interface{}{
+			date.Format("2006-01-02"),
+			fmt.Sprintf("%.2f", prices.Open),
+			fmt.Sprintf("%.2f", prices.High),
+			fmt.Sprintf("%.2f", prices.Low),
+			fmt.Sprintf("%.2f", prices.Close),
+		})
+	}
+	return t.Render() + "\n"
+}
+
+func Execute(from string, to string, format flags.OutputFormat, interval flags.Interval, begin string, end string, full bool) (string, error) {
+	beginTime, endTime, err := internal.ValidateDates(begin, end)
+	if err != nil {
+		return "", err
+	}
+
+	url, err := buildURL(from, to, format, interval, full)
+	if err != nil {
+		return "", err
+	}
+
+	body, err := internal.HTTPRequest(url)
+	if err != nil {
+		return "", err
+	}
+
+	response, err := createResponseObject(interval)
+	if err != nil {
+		return "", err
+	}
+
+	return response.GenerateOutput(body, beginTime, endTime, format)
+}

--- a/internal/currency/rate/rate.go
+++ b/internal/currency/rate/rate.go
@@ -21,14 +21,16 @@ package rate
 import (
 	"errors"
 	"fmt"
-	"github.com/jedib0t/go-pretty/v6/table"
-	"github.com/lentidas/hledger-price-tracker/internal"
-	currencyList "github.com/lentidas/hledger-price-tracker/internal/currency/list"
-	"github.com/lentidas/hledger-price-tracker/internal/flags"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+
+	"github.com/lentidas/hledger-price-tracker/internal"
+	currencyList "github.com/lentidas/hledger-price-tracker/internal/currency/list"
+	"github.com/lentidas/hledger-price-tracker/internal/flags"
 )
 
 // TODO Add documentation to each of the functions

--- a/internal/currency/rate/rate_test.go
+++ b/internal/currency/rate/rate_test.go
@@ -1,0 +1,179 @@
+/*
+ * hledger-price-tracker - a CLI tool to get market prices for commodities
+ * Copyright (C) 2024 Gonçalo Carvalheiro Heleno
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package rate
+
+import (
+	"testing"
+
+	"github.com/lentidas/hledger-price-tracker/internal"
+	"github.com/lentidas/hledger-price-tracker/internal/flags"
+)
+
+func TestRate(t *testing.T) {
+	internal.ApiKey = "demo"
+
+	t.Run("success from EUR to USD daily", func(t *testing.T) {
+		if _, err := Execute("EUR", "USD", flags.OutputFormatHledger, flags.IntervalDaily, "", "", false); err != nil {
+			t.Errorf("expected nil, got %v", err)
+		}
+	})
+
+	t.Run("success from EUR to USD daily full", func(t *testing.T) {
+		if _, err := Execute("EUR", "USD", flags.OutputFormatHledger, flags.IntervalDaily, "", "", true); err != nil {
+			t.Errorf("expected nil, got %v", err)
+		}
+	})
+
+	t.Run("success from EUR to USD weekly", func(t *testing.T) {
+		if _, err := Execute("EUR", "USD", flags.OutputFormatHledger, flags.IntervalWeekly, "", "", false); err != nil {
+			t.Errorf("expected nil, got %v", err)
+		}
+	})
+
+	t.Run("success from EUR to USD monthly", func(t *testing.T) {
+		if _, err := Execute("EUR", "USD", flags.OutputFormatHledger, flags.IntervalMonthly, "", "", false); err != nil {
+			t.Errorf("expected nil, got %v", err)
+		}
+	})
+
+	t.Run("no origin currency", func(t *testing.T) {
+		if _, err := Execute("", "USD", flags.OutputFormatHledger, flags.IntervalDaily, "", "", false); err == nil {
+			t.Error("expected error, got nil")
+		}
+	})
+
+	t.Run("no destination currency", func(t *testing.T) {
+		if _, err := Execute("EUR", "", flags.OutputFormatHledger, flags.IntervalDaily, "", "", false); err == nil {
+			t.Error("expected error, got nil")
+		}
+	})
+
+	t.Run("invalid origin currency", func(t *testing.T) {
+		if _, err := Execute("INVALID", "USD", flags.OutputFormatHledger, flags.IntervalDaily, "", "", false); err == nil {
+			t.Error("expected error, got nil")
+		}
+	})
+
+	t.Run("invalid destination currency", func(t *testing.T) {
+		if _, err := Execute("EUR", "INVALID", flags.OutputFormatHledger, flags.IntervalDaily, "", "", false); err == nil {
+			t.Error("expected error, got nil")
+		}
+	})
+
+	t.Run("invalid output format", func(t *testing.T) {
+		if _, err := Execute("EUR", "USD", "invalid", flags.IntervalDaily, "", "", false); err == nil {
+			t.Error("expected error, got nil")
+		}
+	})
+
+	t.Run("invalid interval", func(t *testing.T) {
+		if _, err := Execute("EUR", "USD", flags.OutputFormatHledger, "invalid", "", "", false); err == nil {
+			t.Error("expected error, got nil")
+		}
+	})
+
+	internal.ApiKey = ""
+
+	t.Run("no API key", func(t *testing.T) {
+		if _, err := Execute("USD", "JPY", flags.OutputFormatHledger, flags.IntervalDaily, "", "", false); err == nil {
+			t.Error("expected error, got nil")
+		}
+	})
+}
+
+func TestRateURLBuilder(t *testing.T) {
+	internal.ApiKey = "demo"
+
+	t.Run("daily", func(t *testing.T) {
+		expected := "https://www.alphavantage.co/query?function=FX_DAILY&from_symbol=EUR&to_symbol=USD&apikey=demo"
+
+		url, err := buildURL("EUR", "USD", flags.OutputFormatHledger, flags.IntervalDaily, false)
+		if err != nil {
+			t.Errorf("expected nil, got %v", err)
+		} else if url != expected {
+			t.Errorf("expected %s, got %s", expected, url)
+		}
+	})
+
+	t.Run("daily full", func(t *testing.T) {
+		expected := "https://www.alphavantage.co/query?function=FX_DAILY&from_symbol=EUR&to_symbol=USD&outputsize=full&apikey=demo"
+
+		url, err := buildURL("EUR", "USD", flags.OutputFormatHledger, flags.IntervalDaily, true)
+		if err != nil {
+			t.Errorf("expected nil, got %v", err)
+		} else if url != expected {
+			t.Errorf("expected %s, got %s", expected, url)
+		}
+	})
+
+	t.Run("weekly", func(t *testing.T) {
+		expected := "https://www.alphavantage.co/query?function=FX_WEEKLY&from_symbol=EUR&to_symbol=USD&apikey=demo"
+
+		url, err := buildURL("EUR", "USD", flags.OutputFormatHledger, flags.IntervalWeekly, false)
+		if err != nil {
+			t.Errorf("expected nil, got %v", err)
+		} else if url != expected {
+			t.Errorf("expected %s, got %s", expected, url)
+		}
+	})
+
+	t.Run("weekly ignore full", func(t *testing.T) {
+		expected := "https://www.alphavantage.co/query?function=FX_WEEKLY&from_symbol=EUR&to_symbol=USD&apikey=demo"
+
+		url, err := buildURL("EUR", "USD", flags.OutputFormatHledger, flags.IntervalWeekly, true)
+		if err != nil {
+			t.Errorf("expected nil, got %v", err)
+		} else if url != expected {
+			t.Errorf("expected %s, got %s", expected, url)
+		}
+	})
+
+	t.Run("monthly", func(t *testing.T) {
+		expected := "https://www.alphavantage.co/query?function=FX_MONTHLY&from_symbol=EUR&to_symbol=USD&apikey=demo"
+
+		url, err := buildURL("EUR", "USD", flags.OutputFormatHledger, flags.IntervalMonthly, false)
+		if err != nil {
+			t.Errorf("expected nil, got %v", err)
+		} else if url != expected {
+			t.Errorf("expected %s, got %s", expected, url)
+		}
+	})
+
+	t.Run("monthly ignore full", func(t *testing.T) {
+		expected := "https://www.alphavantage.co/query?function=FX_MONTHLY&from_symbol=EUR&to_symbol=USD&apikey=demo"
+
+		url, err := buildURL("EUR", "USD", flags.OutputFormatHledger, flags.IntervalMonthly, true)
+		if err != nil {
+			t.Errorf("expected nil, got %v", err)
+		} else if url != expected {
+			t.Errorf("expected %s, got %s", expected, url)
+		}
+	})
+
+	t.Run("CSV", func(t *testing.T) {
+		expected := "https://www.alphavantage.co/query?function=FX_DAILY&from_symbol=EUR&to_symbol=USD&outputsize=full&apikey=demo&datatype=csv"
+
+		url, err := buildURL("EUR", "USD", flags.OutputFormatCSV, flags.IntervalDaily, true)
+		if err != nil {
+			t.Errorf("expected nil, got %v", err)
+		} else if url != expected {
+			t.Errorf("expected %s, got %s", expected, url)
+		}
+	})
+}

--- a/internal/currency/rate/ratedaily.go
+++ b/internal/currency/rate/ratedaily.go
@@ -1,0 +1,113 @@
+/*
+ * hledger-price-tracker - a CLI tool to get market prices for commodities
+ * Copyright (C) 2024 Gonçalo Carvalheiro Heleno
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package rate
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/lentidas/hledger-price-tracker/internal/flags"
+	"strings"
+	"time"
+)
+
+const apiFunctionCurrencyRateDaily = "FX_DAILY"
+
+type RawDaily struct {
+	MetaData   RawMetadataDaily     `json:"Meta Data"`
+	TimeSeries map[string]RawPrices `json:"Time Series FX (Daily)"`
+}
+
+type TypedDaily struct {
+	MetaData   TypedMetadataDaily
+	TimeSeries map[time.Time]TypedPrices
+}
+
+type Daily struct {
+	Raw   RawDaily
+	Typed TypedDaily
+}
+
+func (obj *Daily) TypeBody() error {
+	err := obj.Typed.MetaData.TypeBody(obj.Raw.MetaData)
+	if err != nil {
+		return fmt.Errorf("[(*Daily).TypeBody] failure to cast metadata body: %w", err)
+	}
+
+	obj.Typed.TimeSeries = make(map[time.Time]TypedPrices, len(obj.Raw.TimeSeries))
+
+	for date, prices := range obj.Raw.TimeSeries {
+		dateTyped, err := time.Parse("2006-01-02", date)
+		if err != nil {
+			return fmt.Errorf("[(*Daily).TypeBody] error parsing date: %w", err)
+		}
+
+		var pricesTyped TypedPrices
+		err = pricesTyped.TypeBody(prices)
+		if err != nil {
+			return fmt.Errorf("[(*Daily).TypeBody] error casting prices body: %w", err)
+		}
+
+		obj.Typed.TimeSeries[dateTyped] = pricesTyped
+	}
+
+	return nil
+}
+
+func (obj *Daily) GenerateOutput(body []byte, begin time.Time, end time.Time, format flags.OutputFormat) (string, error) {
+	switch format {
+	case flags.OutputFormatJSON, flags.OutputFormatCSV:
+		return string(body), nil
+	case flags.OutputFormatHledger, flags.OutputFormatTable, flags.OutputFormatTableLong:
+		// Parse the JSON body into the Raw struct.
+		err := json.Unmarshal(body, &obj.Raw)
+		if err != nil {
+			return "", fmt.Errorf("[(*Daily).GenerateOutput] failure to unmarshal JSON body: %w", err)
+		}
+
+		// Cast the attributes into proper types.
+		err = obj.TypeBody()
+		if err != nil {
+			return "", fmt.Errorf("[(*Daily).GenerateOutput] error casting response attributes: %w", err)
+		}
+
+		dates := getDates(obj.Typed.TimeSeries, begin, end)
+
+		if format == flags.OutputFormatHledger {
+			return generateOutputHledger(
+					obj.Typed.TimeSeries,
+					dates,
+					obj.Typed.MetaData.FromSymbol,
+					obj.Typed.MetaData.ToSymbol),
+				nil
+		} else {
+			out := strings.Builder{}
+			out.WriteString(generateMetadataTable(
+				obj.Typed.MetaData.FromSymbol,
+				obj.Typed.MetaData.ToSymbol,
+				obj.Typed.MetaData.LastRefreshed))
+			out.WriteString(generateTimeSeriesTable(
+				obj.Typed.TimeSeries,
+				dates))
+			return out.String(), nil
+		}
+	default:
+		return "", errors.New("[(*Daily).GenerateOutput] invalid output format")
+	}
+}

--- a/internal/currency/rate/ratedaily.go
+++ b/internal/currency/rate/ratedaily.go
@@ -22,9 +22,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/lentidas/hledger-price-tracker/internal/flags"
 	"strings"
 	"time"
+
+	"github.com/lentidas/hledger-price-tracker/internal/flags"
 )
 
 const apiFunctionCurrencyRateDaily = "FX_DAILY"

--- a/internal/currency/rate/ratemonthly.go
+++ b/internal/currency/rate/ratemonthly.go
@@ -1,0 +1,114 @@
+/*
+ * hledger-price-tracker - a CLI tool to get market prices for commodities
+ * Copyright (C) 2024 Gonçalo Carvalheiro Heleno
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package rate
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/lentidas/hledger-price-tracker/internal/flags"
+)
+
+const apiFunctionCurrencyRateMonthly = "FX_MONTHLY"
+
+type RawMonthly struct {
+	MetaData   RawMetadata          `json:"Meta Data"`
+	TimeSeries map[string]RawPrices `json:"Time Series FX (Monthly)"`
+}
+
+type TypedMonthly struct {
+	MetaData   TypedMetadata
+	TimeSeries map[time.Time]TypedPrices
+}
+
+type Monthly struct {
+	Raw   RawMonthly
+	Typed TypedMonthly
+}
+
+func (obj *Monthly) TypeBody() error {
+	err := obj.Typed.MetaData.TypeBody(obj.Raw.MetaData)
+	if err != nil {
+		return fmt.Errorf("[(*Monthly).TypeBody] failure to cast metadata body: %w", err)
+	}
+
+	obj.Typed.TimeSeries = make(map[time.Time]TypedPrices, len(obj.Raw.TimeSeries))
+
+	for date, prices := range obj.Raw.TimeSeries {
+		dateTyped, err := time.Parse("2006-01-02", date)
+		if err != nil {
+			return fmt.Errorf("[(*Monthly).TypeBody] error parsing date: %w", err)
+		}
+
+		var pricesTyped TypedPrices
+		err = pricesTyped.TypeBody(prices)
+		if err != nil {
+			return fmt.Errorf("[(*Monthly).TypeBody] error casting prices body: %w", err)
+		}
+
+		obj.Typed.TimeSeries[dateTyped] = pricesTyped
+	}
+
+	return nil
+}
+
+func (obj *Monthly) GenerateOutput(body []byte, begin time.Time, end time.Time, format flags.OutputFormat) (string, error) {
+	switch format {
+	case flags.OutputFormatJSON, flags.OutputFormatCSV:
+		return string(body), nil
+	case flags.OutputFormatHledger, flags.OutputFormatTable, flags.OutputFormatTableLong:
+		// Parse the JSON body into the Raw struct.
+		err := json.Unmarshal(body, &obj.Raw)
+		if err != nil {
+			return "", fmt.Errorf("[(*Monthly).GenerateOutput] failure to unmarshal JSON body: %w", err)
+		}
+
+		// Cast the attributes into proper types.
+		err = obj.TypeBody()
+		if err != nil {
+			return "", fmt.Errorf("[(*Monthly).GenerateOutput] error casting response attributes: %w", err)
+		}
+
+		dates := getDates(obj.Typed.TimeSeries, begin, end)
+
+		if format == flags.OutputFormatHledger {
+			return generateOutputHledger(
+					obj.Typed.TimeSeries,
+					dates,
+					obj.Typed.MetaData.FromSymbol,
+					obj.Typed.MetaData.ToSymbol),
+				nil
+		} else {
+			out := strings.Builder{}
+			out.WriteString(generateMetadataTable(
+				obj.Typed.MetaData.FromSymbol,
+				obj.Typed.MetaData.ToSymbol,
+				obj.Typed.MetaData.LastRefreshed))
+			out.WriteString(generateTimeSeriesTable(
+				obj.Typed.TimeSeries,
+				dates))
+			return out.String(), nil
+		}
+	default:
+		return "", errors.New("[(*Monthly).GenerateOutput] invalid output format")
+	}
+}

--- a/internal/currency/rate/rateweekly.go
+++ b/internal/currency/rate/rateweekly.go
@@ -20,12 +20,9 @@ package rate
 
 import (
 	"encoding/json"
-	"strings"
-
-	// "encoding/json"
 	"errors"
 	"fmt"
-	// "strings"
+	"strings"
 	"time"
 
 	"github.com/lentidas/hledger-price-tracker/internal/flags"

--- a/internal/currency/rate/rateweekly.go
+++ b/internal/currency/rate/rateweekly.go
@@ -1,0 +1,117 @@
+/*
+ * hledger-price-tracker - a CLI tool to get market prices for commodities
+ * Copyright (C) 2024 Gonçalo Carvalheiro Heleno
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package rate
+
+import (
+	"encoding/json"
+	"strings"
+
+	// "encoding/json"
+	"errors"
+	"fmt"
+	// "strings"
+	"time"
+
+	"github.com/lentidas/hledger-price-tracker/internal/flags"
+)
+
+const apiFunctionCurrencyRateWeekly = "FX_WEEKLY"
+
+type RawWeekly struct {
+	MetaData   RawMetadata          `json:"Meta Data"`
+	TimeSeries map[string]RawPrices `json:"Time Series FX (Weekly)"`
+}
+
+type TypedWeekly struct {
+	MetaData   TypedMetadata
+	TimeSeries map[time.Time]TypedPrices
+}
+
+type Weekly struct {
+	Raw   RawWeekly
+	Typed TypedWeekly
+}
+
+func (obj *Weekly) TypeBody() error {
+	err := obj.Typed.MetaData.TypeBody(obj.Raw.MetaData)
+	if err != nil {
+		return fmt.Errorf("[(*Weekly).TypeBody] failure to cast metadata body: %w", err)
+	}
+
+	obj.Typed.TimeSeries = make(map[time.Time]TypedPrices, len(obj.Raw.TimeSeries))
+
+	for date, prices := range obj.Raw.TimeSeries {
+		dateTyped, err := time.Parse("2006-01-02", date)
+		if err != nil {
+			return fmt.Errorf("[(*Weekly).TypeBody] error parsing date: %w", err)
+		}
+
+		var pricesTyped TypedPrices
+		err = pricesTyped.TypeBody(prices)
+		if err != nil {
+			return fmt.Errorf("[(*Weekly).TypeBody] error casting prices body: %w", err)
+		}
+
+		obj.Typed.TimeSeries[dateTyped] = pricesTyped
+	}
+
+	return nil
+}
+
+func (obj *Weekly) GenerateOutput(body []byte, begin time.Time, end time.Time, format flags.OutputFormat) (string, error) {
+	switch format {
+	case flags.OutputFormatJSON, flags.OutputFormatCSV:
+		return string(body), nil
+	case flags.OutputFormatHledger, flags.OutputFormatTable, flags.OutputFormatTableLong:
+		// Parse the JSON body into the Raw struct.
+		err := json.Unmarshal(body, &obj.Raw)
+		if err != nil {
+			return "", fmt.Errorf("[(*Weekly).GenerateOutput] failure to unmarshal JSON body: %w", err)
+		}
+
+		// Cast the attributes into proper types.
+		err = obj.TypeBody()
+		if err != nil {
+			return "", fmt.Errorf("[(*Weekly).GenerateOutput] error casting response attributes: %w", err)
+		}
+
+		dates := getDates(obj.Typed.TimeSeries, begin, end)
+
+		if format == flags.OutputFormatHledger {
+			return generateOutputHledger(
+					obj.Typed.TimeSeries,
+					dates,
+					obj.Typed.MetaData.FromSymbol,
+					obj.Typed.MetaData.ToSymbol),
+				nil
+		} else {
+			out := strings.Builder{}
+			out.WriteString(generateMetadataTable(
+				obj.Typed.MetaData.FromSymbol,
+				obj.Typed.MetaData.ToSymbol,
+				obj.Typed.MetaData.LastRefreshed))
+			out.WriteString(generateTimeSeriesTable(
+				obj.Typed.TimeSeries,
+				dates))
+			return out.String(), nil
+		}
+	default:
+		return "", errors.New("[(*Weekly).GenerateOutput] invalid output format")
+	}
+}

--- a/internal/main.go
+++ b/internal/main.go
@@ -89,20 +89,20 @@ func ValidateDates(begin, end string) (time.Time, time.Time, error) {
 	if begin != "" {
 		beginTime, err = time.Parse("2006-01-02", begin)
 		if err != nil {
-			return time.Now(), time.Now(), fmt.Errorf("[stock.price.Execute] failed to parse begin date: %w", err)
+			return time.Now(), time.Now(), fmt.Errorf("[internal.ValidateDates] failed to parse begin date: %w", err)
 		}
 		if beginTime.After(time.Now()) {
-			return time.Now(), time.Now(), errors.New("[stock.price.Execute] begin date is in the future")
+			return time.Now(), time.Now(), errors.New("[internal.ValidateDates] begin date is in the future")
 		}
 	}
 	if end != "" {
 		endTime, err = time.Parse("2006-01-02", end)
 		if err != nil {
-			return time.Now(), time.Now(), fmt.Errorf("[stock.price.Execute] failed to parse end date: %w", err)
+			return time.Now(), time.Now(), fmt.Errorf("[internal.ValidateDates] failed to parse end date: %w", err)
 		}
 	}
 	if beginTime.After(endTime) {
-		return time.Now(), time.Now(), errors.New("[stock.price.Execute] begin date is after end date")
+		return time.Now(), time.Now(), errors.New("[internal.ValidateDates] begin date is after end date")
 	}
 
 	return beginTime, endTime, nil

--- a/internal/main_test.go
+++ b/internal/main_test.go
@@ -1,0 +1,83 @@
+/*
+ * hledger-price-tracker - a CLI tool to get market prices for commodities
+ * Copyright (C) 2024 Gonçalo Carvalheiro Heleno
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package internal
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestParseCurrenciesCSV(t *testing.T) {
+	t.Run("valid CSV data", func(t *testing.T) {
+		data := []byte("code,name\nUSD,United States Dollar\nEUR,Euro")
+		expected := map[string]string{
+			"USD": "United States Dollar",
+			"EUR": "Euro",
+		}
+
+		result, err := ParseCurrenciesCSV(data)
+		if err != nil {
+			t.Errorf("expected nil, got %v", err)
+		}
+		if !reflect.DeepEqual(result, expected) {
+			t.Errorf("expected %v, got %v", expected, result)
+		}
+	})
+
+	t.Run("empty CSV data", func(t *testing.T) {
+		data := []byte("code,name\n")
+		expected := map[string]string{}
+
+		result, err := ParseCurrenciesCSV(data)
+		if err != nil {
+			t.Errorf("expected nil, got %v", err)
+		}
+		if !reflect.DeepEqual(result, expected) {
+			t.Errorf("expected %v, got %v", expected, result)
+		}
+	})
+
+	t.Run("malformed CSV data", func(t *testing.T) {
+		data := []byte("code,name\nUSD,United States Dollar\nEUR")
+
+		_, err := ParseCurrenciesCSV(data)
+		if err == nil {
+			t.Error("expected error, got nil")
+		}
+	})
+}
+
+func TestValidateDates(t *testing.T) {
+	t.Run("begin date in the future", func(t *testing.T) {
+		date := time.Now()
+		date = date.Add(3 * 24 * time.Hour) // Add 3 days to the current date.
+		dateString := date.Format("2006-01-02")
+
+		if _, _, err := ValidateDates(dateString, ""); err == nil {
+			t.Error("expected error, got nil")
+		}
+	})
+
+	t.Run("begin date after end date", func(t *testing.T) {
+		if _, _, err := ValidateDates("2024-01-01", "2023-12-31"); err == nil {
+			t.Error("expected error, got nil")
+		}
+	})
+}

--- a/internal/stock/price/price.go
+++ b/internal/stock/price/price.go
@@ -309,7 +309,7 @@ func createResponseObject(interval flags.Interval, adjusted bool) (Response, err
 	return obj, nil
 }
 
-// getDates returns the dates in the time series that are within the specified interval.
+// getDatesNormal returns the dates in the time series that are within the specified interval.
 func getDatesNormal(timeSeries map[time.Time]TypedPrices, begin time.Time, end time.Time) []time.Time {
 	var dates []time.Time
 	for date := range timeSeries {
@@ -369,7 +369,7 @@ func generateOutputHledgerAdjusted(timeSeries map[time.Time]TypedPricesAdjusted,
 	return out.String()
 }
 
-// generateMetadataTable generates a table with the metadata for a given stock symbol. It is used to display the
+// generateMetadataTable generates a table with the metadata for a given stock symbol. It is used to display
 // the information about the stock before the table with the stock prices.
 func generateMetadataTable(symbol string, currency string, lastRefreshed time.Time, timeZone string) string {
 	t := table.NewWriter()

--- a/internal/stock/price/price.go
+++ b/internal/stock/price/price.go
@@ -343,8 +343,8 @@ func getDatesAdjusted(timeSeries map[time.Time]TypedPricesAdjusted, begin time.T
 	return dates
 }
 
-// generateOutputHledger generates the output in hledger format for non-adjusted prices.
-func generateOutputHledger(timeSeries map[time.Time]TypedPrices, dates []time.Time, symbol string, currency string) string {
+// generateOutputHledgerNormal generates the output in hledger format for non-adjusted prices.
+func generateOutputHledgerNormal(timeSeries map[time.Time]TypedPrices, dates []time.Time, symbol string, currency string) string {
 	out := strings.Builder{}
 	for _, date := range dates {
 		out.WriteString(fmt.Sprintf("P %s \"%s\" %.2f %s\n",

--- a/internal/stock/price/price_test.go
+++ b/internal/stock/price/price_test.go
@@ -61,9 +61,6 @@ func TestPrice(t *testing.T) {
 	})
 }
 
-// FIXME Fix the tests to use the new functions
-// FIXME Use current_test.go as an example because we should use a if else instead of consecutive if statements.
-
 func TestPriceURLBuilder(t *testing.T) {
 	internal.ApiKey = "demo"
 
@@ -111,6 +108,17 @@ func TestPriceURLBuilder(t *testing.T) {
 		}
 	})
 
+	t.Run("weekly ignore full", func(t *testing.T) {
+		expected := "https://www.alphavantage.co/query?function=TIME_SERIES_WEEKLY&symbol=IBM&apikey=demo"
+
+		url, err := buildURL("IBM", flags.OutputFormatHledger, flags.IntervalWeekly, false, false)
+		if err != nil {
+			t.Errorf("expected nil, got %v", err)
+		} else if url != expected {
+			t.Errorf("expected %s, got %s", expected, url)
+		}
+	})
+
 	t.Run("monthly", func(t *testing.T) {
 		expected := "https://www.alphavantage.co/query?function=TIME_SERIES_MONTHLY&symbol=IBM&apikey=demo"
 
@@ -126,6 +134,17 @@ func TestPriceURLBuilder(t *testing.T) {
 		expected := "https://www.alphavantage.co/query?function=TIME_SERIES_MONTHLY_ADJUSTED&symbol=IBM&apikey=demo"
 
 		url, err := buildURL("IBM", flags.OutputFormatHledger, flags.IntervalMonthly, true, false)
+		if err != nil {
+			t.Errorf("expected nil, got %v", err)
+		} else if url != expected {
+			t.Errorf("expected %s, got %s", expected, url)
+		}
+	})
+
+	t.Run("monthly ignore full", func(t *testing.T) {
+		expected := "https://www.alphavantage.co/query?function=TIME_SERIES_MONTHLY&symbol=IBM&apikey=demo"
+
+		url, err := buildURL("IBM", flags.OutputFormatHledger, flags.IntervalMonthly, false, false)
 		if err != nil {
 			t.Errorf("expected nil, got %v", err)
 		} else if url != expected {

--- a/internal/stock/price/pricedaily.go
+++ b/internal/stock/price/pricedaily.go
@@ -93,7 +93,7 @@ func (obj *Daily) GenerateOutput(body []byte, begin time.Time, end time.Time, fo
 		dates := getDatesNormal(obj.Typed.TimeSeries, begin, end)
 
 		if format == flags.OutputFormatHledger {
-			return generateOutputHledger(
+			return generateOutputHledgerNormal(
 					obj.Typed.TimeSeries,
 					dates,
 					obj.Typed.MetaData.Symbol,

--- a/internal/stock/price/pricemonthly.go
+++ b/internal/stock/price/pricemonthly.go
@@ -93,7 +93,7 @@ func (obj *Monthly) GenerateOutput(body []byte, begin time.Time, end time.Time, 
 		dates := getDatesNormal(obj.Typed.TimeSeries, begin, end)
 
 		if format == flags.OutputFormatHledger {
-			return generateOutputHledger(
+			return generateOutputHledgerNormal(
 					obj.Typed.TimeSeries,
 					dates,
 					obj.Typed.MetaData.Symbol,

--- a/internal/stock/price/priceweekly.go
+++ b/internal/stock/price/priceweekly.go
@@ -93,7 +93,7 @@ func (obj *Weekly) GenerateOutput(body []byte, begin time.Time, end time.Time, f
 		dates := getDatesNormal(obj.Typed.TimeSeries, begin, end)
 
 		if format == flags.OutputFormatHledger {
-			return generateOutputHledger(
+			return generateOutputHledgerNormal(
 					obj.Typed.TimeSeries,
 					dates,
 					obj.Typed.MetaData.Symbol,

--- a/internal/stock/search/search_test.go
+++ b/internal/stock/search/search_test.go
@@ -28,9 +28,11 @@ import (
 func TestSearch(t *testing.T) {
 	internal.ApiKey = "demo"
 
-	// t.Run("success", func(t *testing.T) {
-	// 	// TODO Implement expected response.
-	// })
+	t.Run("success", func(t *testing.T) {
+		if _, err := Execute("tesco", flags.OutputFormatJSON); err != nil {
+			t.Errorf("expected nil, got %v", err)
+		}
+	})
 
 	t.Run("no search query", func(t *testing.T) {
 		if _, err := Execute("", flags.OutputFormatJSON); err == nil {


### PR DESCRIPTION
This PR does the following:

- implements the library to get historical exchange rates between two physical currencies;
- adds documentation for said library implementation, along with some missing documentation from the previous PRs;
- small refactoring and improvements, such as renaming some functions for consistency, creating functions for less repeated code, etc.;